### PR TITLE
Fix for friend name containing 'id' condition (nidhi)

### DIFF
--- a/resolve_raw_data.js
+++ b/resolve_raw_data.js
@@ -33,7 +33,7 @@ async function resolveLinks(raw_links){
     for (let i=0; i<profileLinks.length; i++){
         profileLinks[i] = profileLinks[i].split('?')[0];
         console.log("profile link: " + profileLinks[i]);
-        if (profileLinks[i].indexOf('id') !== -1) {
+        if (profileLinks[i].indexOf('?id') !== -1) {
             messageLinks.push(profileLinks[i].replace('com/profile.php?id=', 'com/messages/t/'));
         } else{
             messageLinks.push(profileLinks[i].replace('com/', 'com/messages/t/'));


### PR DESCRIPTION
Changed 'if' condition check from "id" to "?id" so that it resolves messenger link correctly for friend name containing "id" (e.g. nidhi).