### PR TITLE
Node detection fixed

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -19,7 +19,7 @@ fi
 #Locate install path of node and if not present attempts to install nodejs
 nodel=$(which nodejs || which node)
 echo "Checking node path: $nodel"
-found=$(echo $nodel | grep -E "node|nodejs")
+found=$(echo $nodel | grep -E "/node|/nodejs")
 
 if [ "$found" == "" ];then 
 echo "Node not installed. Do you want to set it up? (y/n)"

--- a/cron.sh
+++ b/cron.sh
@@ -19,7 +19,7 @@ fi
 #Locate install path of node and if not present attempts to install nodejs
 nodel=$(which nodejs || which node)
 echo "Checking node path: $nodel"
-found=$(echo $nodel | grep -E "/node|/nodejs")
+found=$(echo $nodel | grep "/node|/nodejs")
 
 if [ "$found" == "" ];then 
 echo "Node not installed. Do you want to set it up? (y/n)"

--- a/cron.sh
+++ b/cron.sh
@@ -19,7 +19,7 @@ fi
 #Locate install path of node and if not present attempts to install nodejs
 nodel=$(which nodejs || which node)
 echo "Checking node path: $nodel"
-found=$(echo $nodel | grep "/node|/nodejs")
+found=$(echo $nodel | grep -e "/node" -e "/nodejs")
 
 if [ "$found" == "" ];then 
 echo "Node not installed. Do you want to set it up? (y/n)"

--- a/cron.sh
+++ b/cron.sh
@@ -16,11 +16,13 @@ if [ "" == "$PKG_OK" ]; then
   fi
 fi
 
-#Check if node is installed 
-PKG_OK=$(dpkg-query -W --showformat='${Status}\n' nodejs|grep "install ok installed")
-echo "Checking for node: $PKG_OK"
-if [ "" == "$PKG_OK" ]; then
-  echo "Node not installed. Do you want to set it up? (y/n)"
+#Locate install path of node and if not present attempts to install nodejs
+nodel=$(which nodejs || which node)
+echo "Checking node path: $nodel"
+found=$(echo $nodel | grep -E "node|nodejs")
+
+if [ "$found" == "" ];then 
+echo "Node not installed. Do you want to set it up? (y/n)"
   read o
   if [ $o == "y" ];then
 	 echo "Installing nodejs"
@@ -30,9 +32,6 @@ if [ "" == "$PKG_OK" ]; then
 	 exit 1
   fi
 fi
-
-#Locate install path of node
-nodel=$(which nodejs)
 
 echo "Press 1 to add a new cron job, 2 to delete existing or 3 te view all cron jobs"
 #reads user operation from terminal


### PR DESCRIPTION
Problems with `which` command in different shells was fixed by checking for the phrase "/node" or "/nodejs" in the output. Working and tested in bash and zsh.

fixes #26 
